### PR TITLE
docs(README): Update documentation regarding github secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ Once set up, a new `.now` directory will be added to your directory. The `.now` 
 {"orgId":"example_org_id","projectId":"example_project_id"}
 ```
 
+You can save both values in the secrets setting in your repository. Read the [Official documentation](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets) if you want further info on how secrets work on Github.
+
 ### Github Actions
 
 * This is a complete `.github/workflow/deploy.yml` example.
@@ -131,8 +133,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }} #Optional 
           zeit-team-id: team_XXXXXXXXXXX #Optional 
           now-args: '--prod' #Optional
-          now-org-id: 'example_org_id' #Required
-          now-project-id: 'example_project_id' #Required 
+          now-org-id: ${{ secrets.ORG_ID}}  #Required
+          now-project-id: ${{ secrets.PROJECT_ID}} #Required 
           working-directory: ./sub-directory
 ```
 


### PR DESCRIPTION
The documentation was indicating to copy the now org id and now project
id in the github actions config. In order to avoid exposing these
secrets, it's better to document how to use Github secrets instead.

Feel free to close this PR in case I've missed something and got this wrong.